### PR TITLE
Add AI enrichment backfill: src/pipeline/backfill.py (W-0029)

### DIFF
--- a/.github/workflows/backfill-enrichment.yml
+++ b/.github/workflows/backfill-enrichment.yml
@@ -1,0 +1,87 @@
+name: Backfill AI Enrichment
+
+# Ops tool: re-enriches ProcessedItems where theme == "" using the Gemini API.
+# Run this after any period where GEMINI_API_KEY was absent or quota-exhausted,
+# or after the thinking_budget=0 fix (cb6dfe0) to recover items that silently
+# stored unenriched due to finish_reason=MAX_TOKENS.
+#
+# After this workflow commits updated data/processed/ files, trigger
+# rebuild-site.yml manually to regenerate docs/data/*.json.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Which files to backfill: 'all' (all dates) or a specific YYYY-MM-DD"
+        required: true
+        default: "all"
+        type: string
+      dry_run:
+        description: "Dry run — report counts without writing files"
+        required: false
+        default: "false"
+        type: boolean
+      debug:
+        description: "Enable debug logging"
+        required: false
+        default: "false"
+        type: boolean
+
+concurrency:
+  group: backfill-enrichment
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill unenriched items
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build backfill arguments
+        id: args
+        run: |
+          ARGS=""
+          SCOPE="${{ inputs.scope }}"
+          if [ "$SCOPE" = "all" ]; then
+            ARGS="$ARGS --all"
+          else
+            ARGS="$ARGS --date $SCOPE"
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          if [ "${{ inputs.debug }}" = "true" ]; then ARGS="$ARGS --debug"; fi
+          echo "args=$ARGS" >> "$GITHUB_OUTPUT"
+
+      - name: Run enrichment backfill
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: python -m src.pipeline.backfill ${{ steps.args.outputs.args }}
+
+      - name: Commit updated processed data
+        if: ${{ inputs.dry_run != 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/processed/
+          if git diff --cached --quiet; then
+            echo "No changes after backfill — nothing to commit"
+          else
+            git commit -m "chore: backfill AI enrichment for unenriched items [skip ci]"
+            git push origin HEAD
+          fi

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1140,7 +1140,7 @@ Currently `src/trends.py` does its own fetching (arXiv, HuggingFace, etc.) and r
 
 ## W-0029
 
-status: ready
+status: done
 created: 2026-05-09
 updated: 2026-05-09
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -874,3 +874,28 @@ Initialized `.github/skills` submodule and applied `code-review` skill to all ch
 3. **What single change would prevent this next time?** Run `make check` before committing session changes, not after, to avoid a separate lint-only commit.
 4. **Is this a pattern?** Docstring/comment drift happens when root cause diagnoses change mid-session. Comments should be reviewed during the code review pass, not just at time of writing.
 
+
+---
+
+## 2026-05-09 — W-0029: Backfill AI enrichment for unenriched items
+
+### What changed
+
+Implemented `src/pipeline/backfill.py` — a CLI ops tool that re-enriches `ProcessedItem` records where `theme == ""` using the Gemini API.
+
+**Root cause recap:** `gemini-2.5-flash` thinking tokens compete with `max_output_tokens=500`, exhausting the budget before the 8-line structured response is written. `finish_reason=MAX_TOKENS` (not `STOP`) caused every call to silently return `(item, False)`. Fixed in `cb6dfe0` via `thinking_budget=0`. But 165 items in `data/processed/` were already written without enrichment and `_merge_and_write` preserves existing IDs as-is.
+
+**What was delivered:**
+- `src/pipeline/backfill.py`: scans processed files, enriches items with `theme == ""`, writes back in-place. Supports `--all`, `--date`, `--dry-run`, `--debug`. `enrich` is a module-level wrapper (lazy import) so the module can be imported without triggering the google.genai C extension — enables patching in tests.
+- `tests/test_pipeline_backfill.py`: 9 TDD tests covering the full behaviour matrix.
+- `.github/workflows/backfill-enrichment.yml`: `workflow_dispatch` workflow to trigger backfill in production where `GEMINI_API_KEY` is available.
+- W-0029 marked `done` in `BACKLOG.md`.
+
+**To recover the 165 unenriched items:** trigger `backfill-enrichment.yml` with `scope: all` via `workflow_dispatch` on `claude/enrich-items-ai-themes-eI58y`, then run `rebuild-site.yml`.
+
+### Mini-Retro
+
+1. **Did the process work?** Yes — diagnosis first, then TDD, then implementation. Reading `learnings.md` before touching pipeline code surfaced the context immediately.
+2. **What slowed down?** Broken cryptography native extension in the container's system Python prevents `google.genai` from importing during tests. Solved by making `enrich` a module-level wrapper with a lazy inner import, allowing `patch("src.pipeline.backfill.enrich")` to work without google.genai being imported.
+3. **What single change would prevent this next time?** The "lazy import wrapper" pattern for google.genai-dependent modules should be documented in `learnings.md` so future tests don't hit the same import-time friction.
+4. **Is this a pattern?** Yes — any module that imports `google.genai` at module level will fail to collect in this test environment. The pattern to follow: wrap the call in a module-level function with a lazy inner import.

--- a/learnings.md
+++ b/learnings.md
@@ -198,3 +198,32 @@ Without this, targeted test runs can appear hung or exceed CI time budgets even 
 
 **All themes declining = pipeline signal, not trend signal.** When every theme shows `state: declining`, the most likely cause is that no new AI-enriched items have been added in the last 14 days (the `_VOLUME_WINDOW_DAYS`). Check GEMINI_API_KEY and pipeline logs before interpreting declining states as genuine trend signals.
 
+
+---
+
+## 2026-05-09 — Lazy import wrapper pattern for google.genai in tests
+
+### Pattern
+
+Any module that does `from google.genai import types` at module level will fail to collect in the container's system Python test environment. The `cryptography` package has a broken native Rust extension (`pyo3_runtime.PanicException: Python API call failed`) in this environment.
+
+### Fix
+
+Wrap the google.genai-dependent call in a **module-level function** with a lazy inner import:
+
+```python
+def enrich(item, client, max_output_tokens=500):
+    from src.pipeline.stages.enrich import enrich as _enrich  # lazy import
+    return _enrich(item, client, max_output_tokens=max_output_tokens)
+```
+
+This means:
+1. Importing the module does **not** trigger `google.genai` at import time.
+2. Tests can patch `src.mymodule.enrich` cleanly (it is a module-level name).
+3. The real import only fires when the function is actually called in production.
+
+**Applied in:** `src/pipeline/backfill.py` (wraps `src.pipeline.stages.enrich.enrich`).
+
+### Why module-level matters for patching
+
+`patch("src.mymodule.enrich")` only works when `enrich` is a name in `mymodule`'s namespace. A lazy import *inside* a function body creates a local name that cannot be patched from outside. A module-level wrapper function makes the name patchable while still deferring the real import.

--- a/src/pipeline/backfill.py
+++ b/src/pipeline/backfill.py
@@ -1,0 +1,237 @@
+"""Backfill AI enrichment for ProcessedItems where theme is missing.
+
+CLI: python -m src.pipeline.backfill [--all] [--date YYYY-MM-DD] [--dry-run] [--debug]
+
+Reads data/processed/*.jsonl, finds items with theme == "", and re-runs the
+combined AI enrich stage on them. Updates files in-place.
+
+Use --all to scan all processed files (default: today only).
+Use --date to target a specific date.
+Use --dry-run to report counts without writing changes.
+
+This is an ops tool for recovering from periods when GEMINI_API_KEY was absent
+or when gemini-2.5-flash thinking tokens exhausted the max_output_tokens budget
+(fixed in cb6dfe0 via thinking_budget=0).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv  # type: ignore[import-untyped]
+
+    load_dotenv()
+except ImportError:
+    pass
+
+from src.logger import setup_logging
+from src.models import ProcessedItem, read_processed_jsonl, write_processed_jsonl
+from src.retry import with_backoff
+
+logger = logging.getLogger(__name__)
+
+_PROCESSED_DIR = Path("data/processed")
+
+
+class _NullRateLimiter:
+    """No-op rate limiter used in tests and dry-run mode."""
+
+    def wait(self) -> None:
+        pass
+
+
+def enrich(item: ProcessedItem, client: object, max_output_tokens: int = 500):
+    """Thin wrapper around stages.enrich.enrich; imported lazily to avoid triggering
+    google.genai at module load time (which requires the cryptography C extension).
+    Module-level name so tests can patch src.pipeline.backfill.enrich directly.
+    """
+    from src.pipeline.stages.enrich import enrich as _enrich  # noqa: PLC0415
+
+    return _enrich(item, client, max_output_tokens=max_output_tokens)  # type: ignore[arg-type]
+
+
+def backfill_file(
+    path: Path,
+    client: object,
+    rate_limiter: object,
+    max_output_tokens: int,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """Enrich items with theme == '' in a single processed file.
+
+    Returns (enriched_count, failed_count).  When dry_run is True, counts
+    are computed but the file is not written.
+    """
+    items = read_processed_jsonl(path)
+    unenriched = [i for i in items if not i.theme]
+
+    if not unenriched:
+        return 0, 0
+
+    logger.info(
+        "%s: %d unenriched item(s) of %d total", path.name, len(unenriched), len(items)
+    )
+
+    if dry_run:
+        logger.info("Dry run — skipping enrichment calls for %s", path.name)
+        return len(unenriched), 0
+
+    item_map: dict[str, ProcessedItem] = {i.id: i for i in items}
+    enriched_count = 0
+    failed_count = 0
+
+    for item in unenriched:
+        rate_limiter.wait()  # type: ignore[union-attr]
+
+        def _attempt(current: ProcessedItem = item):
+            return enrich(current, client, max_output_tokens=max_output_tokens)  # type: ignore[arg-type]
+
+        try:
+            enriched_item, ok = with_backoff(
+                _attempt,
+                max_attempts=3,
+                base_delay=60.0,
+                label=f"backfill:{item.id}",
+            )
+        except Exception as exc:
+            logger.warning("Backfill failed for %r after retries: %s", item.id, exc)
+            ok = False
+            enriched_item = item
+
+        if ok:
+            item_map[item.id] = enriched_item
+            enriched_count += 1
+            logger.debug("Enriched %r → theme=%r", item.id, enriched_item.theme)
+        else:
+            failed_count += 1
+            logger.warning("Enrichment returned ok=False for %r — keeping defaults", item.id)
+
+    # Preserve original insertion order
+    ordered = [item_map[i.id] for i in items]
+    write_processed_jsonl(ordered, path)
+    logger.info(
+        "%s: enriched %d, failed %d", path.name, enriched_count, failed_count
+    )
+    return enriched_count, failed_count
+
+
+def backfill_all(
+    processed_dir: Path,
+    client: object,
+    rate_limiter: object,
+    max_output_tokens: int,
+    dry_run: bool = False,
+    date_filter: str | None = None,
+) -> tuple[int, int, int]:
+    """Backfill all (or a single date's) processed files.
+
+    Returns (total_enriched, total_failed, files_updated).
+    files_updated counts files where at least one item was enriched (or would
+    be enriched in dry_run mode).
+    """
+    if date_filter:
+        paths = [processed_dir / f"{date_filter}.jsonl"]
+        paths = [p for p in paths if p.exists()]
+    else:
+        paths = sorted(processed_dir.glob("*.jsonl"))
+
+    if not paths:
+        logger.warning("No processed files found in %s", processed_dir)
+        return 0, 0, 0
+
+    total_enriched = 0
+    total_failed = 0
+    files_updated = 0
+
+    for path in paths:
+        enriched, failed = backfill_file(
+            path, client, rate_limiter, max_output_tokens, dry_run=dry_run
+        )
+        total_enriched += enriched
+        total_failed += failed
+        if enriched > 0:
+            files_updated += 1
+
+    return total_enriched, total_failed, files_updated
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Re-enrich ProcessedItems where theme == '' using the Gemini API."
+    )
+    p.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_dates",
+        help="Scan all dates in data/processed/ (default: today only)",
+    )
+    p.add_argument("--date", default=None, help="Target a specific date (YYYY-MM-DD)")
+    p.add_argument("--dry-run", action="store_true", help="Report counts without writing files")
+    p.add_argument("--debug", action="store_true")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    from src.config import load_config
+
+    cfg = load_config()
+    setup_logging(debug=args.debug, log_file=cfg.logging.log_file)
+
+    api_key = os.environ.get("GEMINI_API_KEY") or None
+    if not api_key:
+        logger.error("GEMINI_API_KEY not set — cannot run backfill without an API key")
+        return 1
+
+    from src.pipeline.run import _make_gemini_client, _RateLimiter
+
+    client = _make_gemini_client(api_key)
+    rate_limiter = _RateLimiter(rpm=cfg.pipeline.gemini_rpm)
+
+    if args.date:
+        date_filter = args.date
+    elif args.all_dates:
+        date_filter = None
+    else:
+        date_filter = datetime.now(UTC).strftime("%Y-%m-%d")
+
+    dry_label = " (dry run)" if args.dry_run else ""
+    logger.info(
+        "Backfill%s — target: %s",
+        dry_label,
+        date_filter or "all dates",
+    )
+
+    enriched, failed, files = backfill_all(
+        _PROCESSED_DIR,
+        client,
+        rate_limiter,
+        max_output_tokens=cfg.pipeline.enrich_max_output_tokens,
+        dry_run=args.dry_run,
+        date_filter=date_filter,
+    )
+
+    logger.info(
+        "Backfill complete%s — %d enriched, %d failed, %d file(s) updated",
+        dry_label,
+        enriched,
+        failed,
+        files,
+    )
+
+    if failed and enriched + failed > 0 and failed / (enriched + failed) > 0.5:
+        logger.error("More than 50%% of enrichment attempts failed — check Gemini quota/key")
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pipeline_backfill.py
+++ b/tests/test_pipeline_backfill.py
@@ -1,0 +1,242 @@
+"""TDD tests for src/pipeline/backfill.py — AI enrichment backfill."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from unittest.mock import MagicMock, patch
+
+from src.models import ProcessedItem, write_processed_jsonl
+
+
+def _make_processed(id_: str = "item-1", theme: str = "", summary: str = "") -> ProcessedItem:
+    return ProcessedItem(
+        id=id_,
+        title="Test LLM Article",
+        url=f"https://example.com/{id_}",
+        source_name="Test Source",
+        source_type="rss",
+        source_class="practitioner",
+        author="Alice",
+        published=None,
+        has_code=False,
+        evidence_type="analysis",
+        fetch_date="2026-05-09",
+        cleaned_content="LLM inference research findings.",
+        theme=theme,
+        domain="unknown",
+        summary=summary,
+        concepts=[],
+        actors=[],
+        impact_vector="unknown",
+        is_marketing=False,
+        marketing_confidence=0.0,
+        hype_risk=0.0,
+        credibility_score=0.0,
+    )
+
+
+def _make_enrich_ok(theme: str = "inference scaling"):
+    """Patch target for enrich() that succeeds without importing google.genai."""
+
+    def _enrich(item, client, max_output_tokens=500):
+        enriched = dataclasses.replace(
+            item,
+            theme=theme,
+            domain="infra",
+            concepts=["LLM", "inference"],
+            actors=[],
+            impact_vector="capability",
+            summary="First sentence. Second sentence.",
+            is_marketing=False,
+            marketing_confidence=0.9,
+        )
+        return enriched, True
+
+    return _enrich
+
+
+def _make_enrich_fail():
+    """Patch target for enrich() that returns ok=False."""
+
+    def _enrich(item, client, max_output_tokens=500):
+        return item, False
+
+    return _enrich
+
+
+# ── backfill_file ────────────────────────────────────────────────────────────
+
+
+class TestBackfillFile:
+    """backfill_file(path, client, rate_limiter, max_output_tokens) → (enriched, failed)"""
+
+    def test_unenriched_item_gets_theme(self, tmp_path):
+        """Items with theme == '' are enriched and written back."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_file
+
+        path = tmp_path / "2026-05-09.jsonl"
+        item = _make_processed("a", theme="")
+        write_processed_jsonl([item], path)
+
+        with patch("src.pipeline.backfill.enrich", side_effect=_make_enrich_ok("inference scaling")):
+            enriched, failed = backfill_file(path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 1
+        assert failed == 0
+        result = json.loads(path.read_text().strip())
+        assert result["theme"] == "inference scaling"
+
+    def test_enriched_item_is_not_re_processed(self, tmp_path):
+        """Items that already have a theme are skipped without calling enrich."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_file
+
+        path = tmp_path / "2026-05-09.jsonl"
+        item = _make_processed("a", theme="existing theme")
+        write_processed_jsonl([item], path)
+
+        mock_enrich = MagicMock()
+        with patch("src.pipeline.backfill.enrich", mock_enrich):
+            enriched, failed = backfill_file(path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 0
+        assert failed == 0
+        mock_enrich.assert_not_called()
+        result = json.loads(path.read_text().strip())
+        assert result["theme"] == "existing theme"
+
+    def test_mixed_file_enriches_only_unenriched(self, tmp_path):
+        """Only items with theme == '' are enriched; others are preserved."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_file
+
+        path = tmp_path / "2026-05-09.jsonl"
+        items = [
+            _make_processed("a", theme="existing"),
+            _make_processed("b", theme=""),
+            _make_processed("c", theme="also existing"),
+        ]
+        write_processed_jsonl(items, path)
+
+        call_count = 0
+
+        def _counting_enrich(item, client, max_output_tokens=500):
+            nonlocal call_count
+            call_count += 1
+            return _make_enrich_ok("new theme")(item, client, max_output_tokens)
+
+        with patch("src.pipeline.backfill.enrich", side_effect=_counting_enrich):
+            enriched, failed = backfill_file(path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 1
+        assert failed == 0
+        assert call_count == 1
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+        results = {json.loads(ln)["id"]: json.loads(ln)["theme"] for ln in lines}
+        assert results["a"] == "existing"
+        assert results["b"] == "new theme"
+        assert results["c"] == "also existing"
+
+    def test_empty_file_returns_zero(self, tmp_path):
+        """An empty processed file returns (0, 0) without calling enrich."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_file
+
+        path = tmp_path / "2026-05-09.jsonl"
+        write_processed_jsonl([], path)
+
+        mock_enrich = MagicMock()
+        with patch("src.pipeline.backfill.enrich", mock_enrich):
+            enriched, failed = backfill_file(path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 0
+        assert failed == 0
+        mock_enrich.assert_not_called()
+
+    def test_failed_enrichment_counts_as_failed(self, tmp_path):
+        """When enrich() returns ok=False, item stays unenriched and failed count increments."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_file
+
+        path = tmp_path / "2026-05-09.jsonl"
+        item = _make_processed("a", theme="")
+        write_processed_jsonl([item], path)
+
+        with (
+            patch("src.pipeline.backfill.enrich", side_effect=_make_enrich_fail()),
+            patch("src.retry.time.sleep"),
+        ):
+            enriched, failed = backfill_file(path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 0
+        assert failed == 1
+        result = json.loads(path.read_text().strip())
+        assert result["theme"] == ""
+
+    def test_rate_limiter_called_per_unenriched_item(self, tmp_path):
+        """Rate limiter .wait() is called once per item that needs enrichment."""
+        from src.pipeline.backfill import backfill_file
+
+        path = tmp_path / "2026-05-09.jsonl"
+        items = [_make_processed("a", theme=""), _make_processed("b", theme="")]
+        write_processed_jsonl(items, path)
+
+        rate_limiter = MagicMock()
+        with patch("src.pipeline.backfill.enrich", side_effect=_make_enrich_ok()):
+            backfill_file(path, MagicMock(), rate_limiter, 500)
+
+        assert rate_limiter.wait.call_count == 2
+
+
+# ── backfill_all ─────────────────────────────────────────────────────────────
+
+
+class TestBackfillAll:
+    """backfill_all(processed_dir, client, ...) → (total_enriched, total_failed, files_updated)"""
+
+    def test_scans_all_jsonl_files(self, tmp_path):
+        """Processes every .jsonl file in the directory."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_all
+
+        for date in ("2026-04-01", "2026-04-02"):
+            p = tmp_path / f"{date}.jsonl"
+            write_processed_jsonl([_make_processed(f"item-{date}", theme="")], p)
+
+        with patch("src.pipeline.backfill.enrich", side_effect=_make_enrich_ok()):
+            enriched, failed, files = backfill_all(tmp_path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 2
+        assert failed == 0
+        assert files == 2
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        """In dry_run mode, counts are reported but files are not modified."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_all
+
+        path = tmp_path / "2026-05-09.jsonl"
+        item = _make_processed("a", theme="")
+        write_processed_jsonl([item], path)
+        original = path.read_text()
+
+        mock_enrich = MagicMock()
+        with patch("src.pipeline.backfill.enrich", mock_enrich):
+            enriched, failed, files = backfill_all(
+                tmp_path, MagicMock(), _NullRateLimiter(), 500, dry_run=True
+            )
+
+        assert enriched == 1
+        assert files == 1
+        assert path.read_text() == original
+        mock_enrich.assert_not_called()
+
+    def test_files_with_no_unenriched_items_not_counted(self, tmp_path):
+        """Files where all items are already enriched do not increment files_updated."""
+        from src.pipeline.backfill import _NullRateLimiter, backfill_all
+
+        path = tmp_path / "2026-05-09.jsonl"
+        write_processed_jsonl([_make_processed("a", theme="existing")], path)
+
+        mock_enrich = MagicMock()
+        with patch("src.pipeline.backfill.enrich", mock_enrich):
+            enriched, failed, files = backfill_all(tmp_path, MagicMock(), _NullRateLimiter(), 500)
+
+        assert enriched == 0
+        assert files == 0
+        mock_enrich.assert_not_called()


### PR DESCRIPTION
Root cause: gemini-2.5-flash thinking tokens competed with max_output_tokens=500,
causing finish_reason=MAX_TOKENS on every call. enrich() silently returned
(item, False), leaving 165 items without themes. Fixed in cb6dfe0 (thinking_budget=0)
but _merge_and_write preserves existing IDs as-is — already-written unenriched items
need an explicit backfill pass.

What this adds:
- src/pipeline/backfill.py: scans data/processed/*.jsonl, enriches items where
  theme == "", writes back in-place. Flags: --all, --date, --dry-run, --debug.
  Uses a module-level enrich() wrapper with a lazy inner import so the module
  can be imported without the google.genai C extension (enables patching in tests).
- tests/test_pipeline_backfill.py: 9 TDD tests — enriches unenriched, skips
  already-enriched, dry-run does not write, rate limiter paced, failed enrich counted.
- .github/workflows/backfill-enrichment.yml: workflow_dispatch workflow for
  triggering backfill in production where GEMINI_API_KEY is available.
- W-0029 marked done in BACKLOG.md
- PROGRESS.md and learnings.md updated

To recover the 165 unenriched items: trigger backfill-enrichment.yml with
scope=all, then rebuild-site.yml.

https://claude.ai/code/session_01D5PMpjoQbrbgkVrk6DZaJc